### PR TITLE
Add windows support with ExecutePowershell

### DIFF
--- a/component.yml.tpl
+++ b/component.yml.tpl
@@ -4,7 +4,7 @@ description: ${description}
 %{ endif ~}
 schemaVersion: 1.0
 phases:
-  - name: build
+  - name: ${phase}
     steps:
       - name: arbitrary-script
         action: ${action}

--- a/component.yml.tpl
+++ b/component.yml.tpl
@@ -4,10 +4,10 @@ description: ${description}
 %{ endif ~}
 schemaVersion: 1.0
 phases:
-  - name: ${phase}
+  - name: build
     steps:
       - name: arbitrary-script
-        action: ExecuteBash
+        action: ${action}
         inputs:
           commands:
             ${ indent(12, chomp(yamlencode(commands))) }

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,11 @@
 locals {
   latest_component_minor_version = "${split(".", var.component_version)[0]}.${split(".", var.component_version)[1]}.x"
+  action                         = var.platform == "Linux" ? "ExecuteBash" : "ExecutePowershell"
 
   data = templatefile("${path.module}/component.yml.tpl", {
     description = var.description
     name        = var.name
+    action      = local.action
     commands    = var.commands
     phase       = var.phase
   })


### PR DESCRIPTION
This feature adds the ability to switch the action in the document to "ExecutePowershell" by setting var.platform to Windows.

Closes #9 