### PR TITLE
"ExecutePowerShell" is apparently case-sensitive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   latest_component_minor_version = "${split(".", var.component_version)[0]}.${split(".", var.component_version)[1]}.x"
-  action                         = var.platform == "Linux" ? "ExecuteBash" : "ExecutePowershell"
+  action                         = var.platform == "Linux" ? "ExecuteBash" : "ExecutePowerShell"
 
   data = templatefile("${path.module}/component.yml.tpl", {
     description = var.description


### PR DESCRIPTION
Regrettably, I wasn't aware that "ExecutePowershell" would be rejected by the AWS API. Looks like the docs stipulate that this must be "ExecutePowerShell."